### PR TITLE
Add kv- prefix to random Key Vault name

### DIFF
--- a/istio/keyvault.tf
+++ b/istio/keyvault.tf
@@ -6,7 +6,7 @@ resource "azurerm_resource_group" "keyvault" {
  }
 
 resource "azurerm_key_vault" "this" {
-  name                       = random_string.random.result
+  name                       = "kv-${random_string.random.result}"
   location                   = azurerm_resource_group.keyvault.location
   resource_group_name        = azurerm_resource_group.keyvault.name
   tenant_id                  = data.azurerm_client_config.current.tenant_id


### PR DESCRIPTION
Fixes KeyVault creation random failure when the random string starts with a number. The name must start with letter.

https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftkeyvault

Used `kv-` prefix as per Microsoft best practice:

https://docs.microsoft.com/en-us/azure/cloud-adoption-framework/ready/azure-best-practices/resource-abbreviations#management-and-governance