### PR TITLE
Fix regression introduced when the kv- prefix was added to the keyvau…

### DIFF
--- a/istio/secret-provider-class.tf
+++ b/istio/secret-provider-class.tf
@@ -1,12 +1,12 @@
 
 
 output "secret-provider-class-westeurope" {
-  value = templatefile("secret-provider-class.tftpl", { userAssignedIdentityID = module.aks-westeurope.key_vault_secrets_provider.secret_identity[0].client_id, vaultname = random_string.random.result, tenant = data.azurerm_client_config.current.tenant_id, location = "westeurope" })
+  value = templatefile("secret-provider-class.tftpl", { userAssignedIdentityID = module.aks-westeurope.key_vault_secrets_provider.secret_identity[0].client_id, vaultname = azurerm_key_vault.this.name, tenant = data.azurerm_client_config.current.tenant_id, location = "westeurope" })
 }
 output "secret-provider-class-eastus" {
-  value = templatefile("secret-provider-class.tftpl", { userAssignedIdentityID = module.aks-eastus.key_vault_secrets_provider.secret_identity[0].client_id, vaultname = random_string.random.result, tenant = data.azurerm_client_config.current.tenant_id, location = "eastus" })
+  value = templatefile("secret-provider-class.tftpl", { userAssignedIdentityID = module.aks-eastus.key_vault_secrets_provider.secret_identity[0].client_id, vaultname = azurerm_key_vault.this.name, tenant = data.azurerm_client_config.current.tenant_id, location = "eastus" })
 }
 
 output "secret-provider-class-ingress" {
-  value = templatefile("secret-provider-class-ingress.tftpl", { userAssignedIdentityID = module.aks-eastus.key_vault_secrets_provider.secret_identity[0].client_id, vaultname = random_string.random.result, tenant = data.azurerm_client_config.current.tenant_id })
+  value = templatefile("secret-provider-class-ingress.tftpl", { userAssignedIdentityID = module.aks-eastus.key_vault_secrets_provider.secret_identity[0].client_id, vaultname = azurerm_key_vault.this.name, tenant = data.azurerm_client_config.current.tenant_id })
 }


### PR DESCRIPTION
In PR #3 I introduced a regression, the wrong Azure Key Vault name is referenced in the `SecretProviderClass`. This PR fixes the issue.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

