### PR TITLE
affinity for istiod and istio-ingressgateway to AKS system nodepool

### DIFF
--- a/istio/scripts/07-install-istio.sh
+++ b/istio/scripts/07-install-istio.sh
@@ -16,7 +16,8 @@ istioctl install -y \
   -f 001-accessLogFile.yaml \
   -f 002-multicluster-region-one.yaml \
   -f 003-istiod-csi-secrets.yaml \
-  -f 004-ingress-gateway.yaml
+  -f 004-ingress-gateway.yaml \
+  -f 005-aks-affinity.yaml
 
 # Install Istio on cluster two
 istioctl install -y \
@@ -27,5 +28,6 @@ istioctl install -y \
   -f 001-accessLogFile.yaml \
   -f 002-multicluster-region-two.yaml \
   -f 003-istiod-csi-secrets.yaml \
-  -f 004-ingress-gateway.yaml
+  -f 004-ingress-gateway.yaml \
+  -f 005-aks-affinity.yaml
 )

--- a/istio/yaml/004-ingress-gateway-csi.yaml
+++ b/istio/yaml/004-ingress-gateway-csi.yaml
@@ -14,6 +14,29 @@ spec:
       k8s:
         service:
           type: ClusterIP
+        affinity:
+          nodeAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - preference:
+                matchExpressions:
+                - key: kubernetes.azure.com/mode
+                  operator: In
+                  values:
+                  - system
+              weight: 100
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+              - matchExpressions:
+                - key: kubernetes.azure.com/cluster
+                  operator: Exists
+                - key: type
+                  operator: NotIn
+                  values:
+                  - virtual-kubelet
+                - key: kubernetes.io/os
+                  operator: In
+                  values:
+                  - linux
         overlays:
           - kind: Deployment
             name: ingressgateway

--- a/istio/yaml/005-aks-affinity.yaml
+++ b/istio/yaml/005-aks-affinity.yaml
@@ -1,19 +1,11 @@
-# https://istio.io/latest/docs/setup/additional-setup/gateway/
 ---
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
-metadata:
-  name: ingress
 spec:
-  profile: empty # Do not install CRDs or the control plane
   components:
-    ingressGateways:
-    - name: ingressgateway
-      namespace: istio-ingress
+    pilot:
       enabled: true
       k8s:
-        service:
-          type: ClusterIP
         affinity:
           nodeAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:
@@ -37,13 +29,3 @@ spec:
                   operator: In
                   values:
                   - linux
-      label:
-        # Set a unique label for the gateway. This is required to ensure Gateways
-        # can select this workload
-        istio: ingressgateway
-  values:
-    gateways:
-      istio-ingressgateway:
-        # Enable gateway injection
-        injectionTemplate: gateway
-


### PR DESCRIPTION
## Purpose

AKS has a `system` nodepool where the critical control plan components should be scheduled, and a `user` nodepool where the user applications should be deployed.

Being Istio control plane and istio-ingressgateway critical components, the pods should have the correct Affinity to prefer the `system` nodepool.

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

Checkout the code:

```
git fetch origin pull/8/head:pr8
git checkout pr8
```

Customize `terraform.tfvars` and `00-variables.sh`. For the sake of testing this PR just change the strict necessary.

Run terraform:

```
terraform init -upgrade && terraform apply -var-file=terraform.tfvars
```
go in the scripts folder and run all the scripts in order.

Check if the istio components are scheduled to AKS nodes belonging to the system nodepool:

`kubectl get pods -n istio-system -o wide`
`kubectl get pods -n istio-ingress -o wide`

